### PR TITLE
Add link to new4j browser on the Dev UI (if started by Dev Services)

### DIFF
--- a/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
@@ -35,6 +35,7 @@ class Neo4jDevServicesProcessor {
     private static final Logger log = Logger.getLogger("io.quarkus.neo4j.deployment");
 
     private static final String NEO4J_URI = "quarkus.neo4j.uri";
+    private static final String NEO4J_BROWSER_URL = "quarkus.neo4j.browser-url";
     private static final String NEO4J_USER_PROP = "quarkus.neo4j.authentication.username";
     private static final String NEO4J_PASSWORD_PROP = "quarkus.neo4j.authentication.password";
 
@@ -72,6 +73,8 @@ class Neo4jDevServicesProcessor {
             if (neo4jContainer != null) {
                 devServicePropertiesProducer.produce(
                         new DevServicesConfigResultBuildItem(NEO4J_URI, neo4jContainer.getBoltUrl()));
+                devServicePropertiesProducer.produce(
+                        new DevServicesConfigResultBuildItem(NEO4J_BROWSER_URL, neo4jContainer.getBrowserUrl()));
                 devServicePropertiesProducer.produce(new DevServicesConfigResultBuildItem(NEO4J_USER_PROP, "neo4j"));
                 devServicePropertiesProducer.produce(new DevServicesConfigResultBuildItem(NEO4J_PASSWORD_PROP,
                         neo4jContainer.getAdminPassword()));

--- a/deployment/src/main/resources/dev-templates/embedded.html
+++ b/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,6 @@
+{#if config:property('quarkus.neo4j.devservices.enabled') != 'false'}
+<a href="{config:property('quarkus.neo4j.browser-url')}" class="badge badge-light">
+  <i class="fas fa-project-diagram"></i>
+  Neo4J Browser</a>
+<br>
+{/if}


### PR DESCRIPTION
As discussed in the insights, this PR will add a link to the neo4j browser in Dev UI.

![Peek 2022-02-15 21-27](https://user-images.githubusercontent.com/6836179/154043621-d02f72fc-3d6a-42e6-a4ba-fe6fdc84e5ff.gif)


Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>