### PR TITLE
Release 1.0.6

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 1.0.5
-  next-version: 1.0.6-SNAPSHOT
+  current-version: 1.0.6
+  next-version: 1.0.7-SNAPSHOT
 


### PR DESCRIPTION
Shortly after the 1.0.5 so that we have the driver dependency bumped to a fixed version with Micrometer support.