### PR TITLE
Use application.properties to retrieve URI and password.

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.7.4.Final
+:quarkus-version: 2.7.5.Final
 :quarkus-neo4j-version: 1.0.5
 :maven-version: 3.8.1+
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -158,15 +158,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <neo4j.uri>${neo4j.uri}</neo4j.uri>
-                                <neo4j.password>${neo4j.password}</neo4j.password>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>
@@ -179,8 +170,6 @@
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                         <maven.home>${maven.home}</maven.home>
-                                        <neo4j.uri>${neo4j.uri}</neo4j.uri>
-                                        <neo4j.password>${neo4j.password}</neo4j.password>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/integration-tests/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,10 +44,20 @@ public class Neo4jFunctionalityTest {
     private Long apfelId;
 
     @BeforeAll
-    public static void connectDriver() {
+    public static void connectDriver() throws IOException {
 
-        var uri = System.getProperty("neo4j.uri", "bolt://localhost:7687");
-        var password = System.getProperty("neo4j.password", "secret");
+        var properties = new Properties();
+        properties.load(Neo4jFunctionalityTest.class.getResourceAsStream("/application.properties"));
+        var defaultUri = "bolt://localhost:7687";
+        var uri = properties.getProperty("quarkus.neo4j.uri", defaultUri);
+        if (uri.startsWith("$")) {
+            uri = defaultUri;
+        }
+        var defaultPassword = "secret";
+        var password = properties.getProperty("quarkus.neo4j.authentication.password", defaultPassword);
+        if (uri.startsWith("$")) {
+            password = defaultPassword;
+        }
         driver = GraphDatabase.driver(uri, AuthTokens.basic("neo4j", password));
     }
 


### PR DESCRIPTION
Maven Release plugin and surefire surely disagrees on what System properties to pass and I don't have the mood to fight them, so I just naively parse the application.properties file that exists anyway and in which the placeholders are correctly supported.﻿
