### PR TITLE
Upgrade devservices to use Neo4j 4.4 by default.

### DIFF
--- a/deployment/src/main/java/io/quarkus/neo4j/deployment/DevServicesBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkus/neo4j/deployment/DevServicesBuildTimeConfig.java
@@ -22,7 +22,7 @@ public class DevServicesBuildTimeConfig {
     /**
      * The container image name to use, for container based DevServices providers.
      */
-    @ConfigItem(defaultValue = "neo4j:4.3")
+    @ConfigItem(defaultValue = "neo4j:4.4")
     public String imageName;
 
     /**

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.11.3.Final
+:quarkus-version: 2.12.1.Final
 :quarkus-neo4j-version: 1.4.1
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-neo4j-config-group-dev-services-build-time-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-neo4j-config-group-dev-services-build-time-config.adoc
@@ -29,7 +29,7 @@ The container image name to use, for container based DevServices providers.
 
 Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_IMAGE_NAME+++`
 --|string 
-|`neo4j:4.3`
+|`neo4j:4.4`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-neo4j-config-group-dev-services-build-time-config_quarkus.neo4j.devservices.bolt-port]]`link:#quarkus-neo4j-config-group-dev-services-build-time-config_quarkus.neo4j.devservices.bolt-port[quarkus.neo4j.devservices.bolt-port]`

--- a/docs/modules/ROOT/pages/includes/quarkus-neo4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-neo4j.adoc
@@ -40,7 +40,7 @@ The container image name to use, for container based DevServices providers.
 
 Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_IMAGE_NAME+++`
 --|string 
-|`neo4j:4.3`
+|`neo4j:4.4`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus.neo4j.devservices.bolt-port]]`link:#quarkus-neo4j_quarkus.neo4j.devservices.bolt-port[quarkus.neo4j.devservices.bolt-port]`

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 = Quarkus Neo4j
 
-:neo4j_version: 4.3
+:neo4j_version: 4.4
 
 include::./includes/attributes.adoc[]
 


### PR DESCRIPTION
The change is long overdue since 4.3 CE is no longer supported.
