### PR TITLE
issue/backports 20230102

### DIFF
--- a/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
+++ b/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
@@ -30,7 +30,7 @@ public class Neo4jDevModeTests {
         static QuarkusUnitTest test = new QuarkusUnitTest()
                 .withEmptyApplication()
                 .withConfigurationResource("application.properties")
-                .overrideConfigKey("quarkus.neo4j.devservices.additional-env.NEO4JLABS_PLUGINS", "[\"apoc\"]")
+                .overrideConfigKey("quarkus.neo4j.devservices.additional-env.NEO4JLABS_PLUGINS", "[\"apoc-core\"]")
                 .setLogRecordPredicate(record -> true)
                 .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage)
                         .contains("Dev Services started a Neo4j container reachable at %s"));

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>Dysprosium-SR25</version>
+                <version>2022.0.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.40.2</version>
+                <version>0.40.3</version>
                 <configuration>
                     <images>
                         <image>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <quarkus.version>2.14.2.Final</quarkus.version>
         <assertj.version>3.23.1</assertj.version>
 
-        <neo4j-java-driver.version>4.4.9</neo4j-java-driver.version>
+        <neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse</groupId>
         <artifactId>quarkiverse-parent</artifactId>
-        <version>11</version>
+        <version>12</version>
     </parent>
     <groupId>io.quarkiverse.neo4j</groupId>
     <artifactId>quarkus-neo4j-parent</artifactId>


### PR DESCRIPTION
- Bump quarkiverse-parent from 11 to 12 (#116)
- Bump reactor-bom from Dysprosium-SR25 to 2022.0.1 (#117)
- Bump docker-maven-plugin from 0.40.2 to 0.40.3 (#118)
- Bump neo4j-java-driver from 4.4.9 to 4.4.11
- refactor: Use only `apoc-core` for testing config.
