### PR TITLE
issue/backports 20230109

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>2.15.2.Final</quarkus.version>
-        <assertj.version>3.23.1</assertj.version>
+        <assertj.version>3.24.1</assertj.version>
 
         <neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>2.14.2.Final</quarkus.version>
+        <quarkus.version>2.15.2.Final</quarkus.version>
         <assertj.version>3.23.1</assertj.version>
 
         <neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>


### PR DESCRIPTION
- Bump quarkus.version from 2.14.2.Final to 2.15.2.Final (#122)
- Bump assertj-core from 3.23.1 to 3.24.1 (#124)
