### PR TITLE
Release 3.0.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 3.0.0
-  next-version: 3.0.1-SNAPSHOT
+  current-version: 3.0.3
+  next-version: 3.0.4-SNAPSHOT
 


### PR DESCRIPTION
Picked 3.0.3 as a version, skipping 3.0.1 and 3.0.2 to keep aligned with Quarkus for a change.