### PR TITLE
Fix asciidoc warnings by using proper link

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -344,7 +344,7 @@ To make life a bit easier, we will use https://smallrye.io/smallrye-mutiny/[Muti
 .Mutiny
 ====
 The following example uses Mutiny reactive types.
-If you are not familiar with Mutiny, check xref:mutiny-primer.adoc[Mutiny - an intuitive reactive programming library].
+If you are not familiar with Mutiny, check {quarkus-guides-url}/mutiny-primer[Mutiny - an intuitive reactive programming library].
 ====
 
 The reactive fruit resources streams the name of all fruits:


### PR DESCRIPTION
Proof of all warnings gone:
<img width="310" alt="image" src="https://github.com/quarkiverse/quarkus-neo4j/assets/11942401/c338c02d-6e19-4803-8e15-976544f22b0c">

Proof of warnings before this PR:
<img width="758" alt="image" src="https://github.com/quarkiverse/quarkus-neo4j/assets/11942401/87b8c4b7-eaf1-45a9-a07c-ee2a3bfdd45b">

@gastaldi @michael-simons when you have a bit of time please review :)