### PR TITLE
Update default Neo4j image version for DevServices

### DIFF
--- a/deployment/src/main/java/io/quarkus/neo4j/deployment/DevServicesBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkus/neo4j/deployment/DevServicesBuildTimeConfig.java
@@ -22,7 +22,7 @@ public class DevServicesBuildTimeConfig {
     /**
      * The container image name to use, for container based DevServices providers.
      */
-    @ConfigItem(defaultValue = "neo4j:4.4")
+    @ConfigItem(defaultValue = "neo4j:5")
     public String imageName;
 
     /**

--- a/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
+++ b/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
@@ -30,7 +30,7 @@ public class Neo4jDevModeTests {
         static QuarkusUnitTest test = new QuarkusUnitTest()
                 .withEmptyApplication()
                 .withConfigurationResource("application.properties")
-                .overrideConfigKey("quarkus.neo4j.devservices.additional-env.NEO4JLABS_PLUGINS", "[\"apoc-core\"]")
+                .overrideConfigKey("quarkus.neo4j.devservices.additional-env.NEO4J_PLUGINS", "[\"apoc\"]")
                 .setLogRecordPredicate(record -> true)
                 .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage)
                         .contains("Dev Services started a Neo4j container reachable at %s"));
@@ -44,7 +44,7 @@ public class Neo4jDevModeTests {
             assertThatNoException().isThrownBy(() -> driver.verifyConnectivity());
             try (var session = driver.session()) {
                 var apoc = session.run("RETURN apoc.version() AS output").single().get(0).asString();
-                assertThat(apoc).isNotNull().startsWith("4.");
+                assertThat(apoc).isNotNull().startsWith("5.");
             }
         }
     }


### PR DESCRIPTION
I'm trying to implement a Neo4j embedding store for the [quarkus-langchain4j extension](https://github.com/quarkiverse/quarkus-langchain4j) so I need vector search capabilities, which seem to be added in Neo4j 5.x. Therefore it would be nice to upgrade the default version, so we don't have to either add a hack in the `quarkus-langchain4j` extension to override the default, or require end users to do it.