### PR TITLE
Release 4.0.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: 3.10.0
-  next-version: 3.10.1-SNAPSHOT
+  current-version: 4.0.0
+  next-version: 4.0.1-SNAPSHOT
 


### PR DESCRIPTION
Major version bump due to the bump from 4.4 to 5 of the default Neo4j images in dev-services. No other changes.