### PR TITLE
fix: Always create a metrics consumer.

### DIFF
--- a/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
+++ b/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.neo4j.deployment;
 
-import java.util.function.Consumer;
-
 import org.neo4j.driver.Driver;
 
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -19,7 +17,6 @@ import io.quarkus.deployment.metrics.MetricsFactoryConsumerBuildItem;
 import io.quarkus.neo4j.runtime.Neo4jConfiguration;
 import io.quarkus.neo4j.runtime.Neo4jDriverRecorder;
 import io.quarkus.runtime.RuntimeValue;
-import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
 class Neo4jDriverProcessor {
@@ -58,11 +55,7 @@ class Neo4jDriverProcessor {
     void metrics(Neo4jConfiguration configuration,
             Neo4jDriverRecorder recorder,
             BuildProducer<MetricsFactoryConsumerBuildItem> metrics) {
-        Consumer<MetricsFactory> metricsFactoryConsumer = recorder.registerMetrics(configuration);
-        // If metrics for neo4j are disabled, the returned consumer will be null,
-        // but in a processor we can't know that (it's controlled by a runtime config property)
-        // so the BuildItem might contain null and in that case will be ignored by the metrics recorder
-        metrics.produce(new MetricsFactoryConsumerBuildItem(metricsFactoryConsumer));
+        metrics.produce(new MetricsFactoryConsumerBuildItem(recorder.registerMetrics(configuration)));
     }
 
     @BuildStep

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.11.1
+:quarkus-version: 3.12.0
 :quarkus-neo4j-version: 4.1.0
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-neo4j-config-group-dev-services-build-time-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-neo4j-config-group-dev-services-build-time-config.adoc
@@ -41,7 +41,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_IMAGE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`neo4j:4.4`
+|`neo4j:5`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-neo4j-config-group-dev-services-build-time-config_quarkus-neo4j-devservices-bolt-port]]`link:#quarkus-neo4j-config-group-dev-services-build-time-config_quarkus-neo4j-devservices-bolt-port[quarkus.neo4j.devservices.bolt-port]`
@@ -78,7 +78,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j-config-group-dev-services-build-time-config_quarkus-neo4j-devservices-additional-env-additional-env]]`link:#quarkus-neo4j-config-group-dev-services-build-time-config_quarkus-neo4j-devservices-additional-env-additional-env[quarkus.neo4j.devservices.additional-env]`
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j-config-group-dev-services-build-time-config_quarkus-neo4j-devservices-additional-env-additional-env]]`link:#quarkus-neo4j-config-group-dev-services-build-time-config_quarkus-neo4j-devservices-additional-env-additional-env[quarkus.neo4j.devservices.additional-env."additional-env"]`
 
 
 [.description]
@@ -86,12 +86,13 @@ a|icon:lock[title=Fixed at build time] [[quarkus-neo4j-config-group-dev-services
 Additional environment entries that can be added to the container before its start.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV__ADDITIONAL_ENV_+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV+++`
+Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV__ADDITIONAL_ENV_+++`
 endif::add-copy-button-to-env-var[]
---|`Map<String,String>` 
+--|link:https://docs.oracle.com/javase/8/docs/api/java/lang/String.html[String]
+ 
 |
 
 |===

--- a/docs/modules/ROOT/pages/includes/quarkus-neo4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-neo4j.adoc
@@ -58,7 +58,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_IMAGE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`neo4j:4.4`
+|`neo4j:5`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-bolt-port]]`link:#quarkus-neo4j_quarkus-neo4j-devservices-bolt-port[quarkus.neo4j.devservices.bolt-port]`
@@ -147,7 +147,7 @@ endif::add-copy-button-to-env-var[]
 |`30S`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env]]`link:#quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env[quarkus.neo4j.devservices.additional-env]`
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env]]`link:#quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env[quarkus.neo4j.devservices.additional-env."additional-env"]`
 
 
 [.description]
@@ -155,12 +155,13 @@ a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices
 Additional environment entries that can be added to the container before its start.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV__ADDITIONAL_ENV_+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV+++`
+Environment variable: `+++QUARKUS_NEO4J_DEVSERVICES_ADDITIONAL_ENV__ADDITIONAL_ENV_+++`
 endif::add-copy-button-to-env-var[]
---|`Map<String,String>` 
+--|link:https://docs.oracle.com/javase/8/docs/api/java/lang/String.html[String]
+ 
 |
 
 

--- a/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
+++ b/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
@@ -71,36 +71,35 @@ public class Neo4jDriverRecorder {
 
     public Consumer<MetricsFactory> registerMetrics(Neo4jConfiguration configuration) {
         if (configuration.pool != null && configuration.pool.metricsEnabled) {
-            return new Consumer<MetricsFactory>() {
-                @Override
-                public void accept(MetricsFactory metricsFactory) {
-                    // if the pool hasn't been used yet, the ConnectionPoolMetrics object doesn't exist, so use zeros instead
-                    metricsFactory.builder("neo4j.acquired").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::acquired).orElse(0L));
-                    metricsFactory.builder("neo4j.acquiring").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::acquiring).orElse(0));
-                    metricsFactory.builder("neo4j.closed").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::closed).orElse(0L));
-                    metricsFactory.builder("neo4j.created").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::created).orElse(0L));
-                    metricsFactory.builder("neo4j.creating").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::creating).orElse(0));
-                    metricsFactory.builder("neo4j.failedToCreate").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::failedToCreate).orElse(0L));
-                    metricsFactory.builder("neo4j.timedOutToAcquire").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::timedOutToAcquire).orElse(0L));
-                    metricsFactory.builder("neo4j.totalAcquisitionTime").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalAcquisitionTime).orElse(0L));
-                    metricsFactory.builder("neo4j.totalConnectionTime").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalConnectionTime).orElse(0L));
-                    metricsFactory.builder("neo4j.totalInUseCount").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalInUseCount).orElse(0L));
-                    metricsFactory.builder("neo4j.totalInUseTime").buildCounter(
-                            () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalInUseCount).orElse(0L));
-                }
+            return metricsFactory -> {
+                // if the pool hasn't been used yet, the ConnectionPoolMetrics object doesn't exist, so use zeros instead
+                metricsFactory.builder("neo4j.acquired").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::acquired).orElse(0L));
+                metricsFactory.builder("neo4j.acquiring").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::acquiring).orElse(0));
+                metricsFactory.builder("neo4j.closed").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::closed).orElse(0L));
+                metricsFactory.builder("neo4j.created").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::created).orElse(0L));
+                metricsFactory.builder("neo4j.creating").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::creating).orElse(0));
+                metricsFactory.builder("neo4j.failedToCreate").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::failedToCreate).orElse(0L));
+                metricsFactory.builder("neo4j.timedOutToAcquire").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::timedOutToAcquire).orElse(0L));
+                metricsFactory.builder("neo4j.totalAcquisitionTime").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalAcquisitionTime).orElse(0L));
+                metricsFactory.builder("neo4j.totalConnectionTime").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalConnectionTime).orElse(0L));
+                metricsFactory.builder("neo4j.totalInUseCount").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalInUseCount).orElse(0L));
+                metricsFactory.builder("neo4j.totalInUseTime").buildCounter(
+                        () -> getConnectionPoolMetrics().map(ConnectionPoolMetrics::totalInUseCount).orElse(0L));
             };
         } else {
-            return null;
+            return metricsFactory -> {
+
+            };
         }
     }
 


### PR DESCRIPTION
Something seems to have changed in Quarkus, so that a `null` consumer is no longer ignored but eventually leads to a crash of the Micrometer processor.

Fixes #265
