### PR TITLE
refactor: Always start devsevices unless a specific URL or port has been specified.

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.neo4j</groupId>
         <artifactId>quarkus-neo4j-parent</artifactId>
-        <version>4.4.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-neo4j-deployment</artifactId>
     <name>Quarkus - Neo4j - Deployment</name>

--- a/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
@@ -135,10 +135,11 @@ class Neo4jDevServicesProcessor {
         }
 
         var boldIsReachable = Boolean.getBoolean("io.quarkus.neo4j.deployment.devservices.assumeBoltIsReachable")
-                || new BoltHandshaker("localhost", 7687).isBoltPortReachable(Duration.ofSeconds(5));
-        if (boldIsReachable) {
+                || new BoltHandshaker("localhost", ExtNeo4jContainer.DEFAULT_BOLT_PORT)
+                        .isBoltPortReachable(Duration.ofSeconds(5));
+        if (boldIsReachable && configuration.fixedBoltPort.orElse(-1) == ExtNeo4jContainer.DEFAULT_BOLT_PORT) {
             log.warn(
-                    "Not starting Dev Services for Neo4j, as the default config points to a reachable address. Be aware that your local database will be used.");
+                    "Not starting Dev Services for Neo4j, as the configuration requests the same fixed bolt port.");
             return null;
         }
 
@@ -168,6 +169,7 @@ class Neo4jDevServicesProcessor {
 
         static ExtNeo4jContainer of(Neo4jDevServiceConfig config) {
 
+            @SuppressWarnings("resource")
             var container = new ExtNeo4jContainer(DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("neo4j"));
             config.fixedBoltPort.ifPresent(port -> container.addFixedExposedPort(port, DEFAULT_BOLT_PORT));
             config.fixedHttpPort.ifPresent(port -> container.addFixedExposedPort(port, DEFAULT_HTTP_PORT));

--- a/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
+++ b/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
@@ -215,9 +215,10 @@ public class Neo4jDevModeTests {
                 .withEmptyApplication()
                 .setLogRecordPredicate(record -> true)
                 .withConfigurationResource("application.properties")
+                .overrideConfigKey("quarkus.neo4j.devservices.bolt-port", "7687")
                 .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage)
                         .anyMatch(s -> s.startsWith(
-                                "Not starting Dev Services for Neo4j, as the default config points to a reachable address.")));
+                                "Not starting Dev Services for Neo4j, as the configuration requests the same fixed bolt port.")));
 
         @AfterAll
         static void deleteSystemPropertyAgain() {

--- a/deployment/src/test/resources/application.properties
+++ b/deployment/src/test/resources/application.properties
@@ -1,8 +1,8 @@
-# I much prefer just setting this but I was not able to capture
+# I much prefer just setting this, but I was not able to capture
 # debug log with QuarkusUnitTest and the InMemoryLogHandler without...
 quarkus.log.category."io.quarkus.neo4j.deployment".level=DEBUG
 
 # Forcing the whole of Quarkus into logging
 quarkus.log.level=DEBUG
-# And than taming console again
+# And then taming console again
 quarkus.log.console.level=INFO

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.15.0
+:quarkus-version: 3.16.0
 :quarkus-neo4j-version: 4.4.0
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-neo4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-neo4j.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-neo4j_quarkus-neo4j
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -8,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-health-enabled]] [.property-path]##`quarkus.neo4j.health.enabled`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-health-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-health-enabled[`quarkus.neo4j.health.enabled`]##
 
 [.description]
 --
@@ -25,7 +24,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-enabled]] [.property-path]##`quarkus.neo4j.devservices.enabled`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-enabled[`quarkus.neo4j.devservices.enabled`]##
 
 [.description]
 --
@@ -42,7 +41,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-image-name]] [.property-path]##`quarkus.neo4j.devservices.image-name`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-image-name]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-image-name[`quarkus.neo4j.devservices.image-name`]##
 
 [.description]
 --
@@ -59,7 +58,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`neo4j:5`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env]] [.property-path]##`quarkus.neo4j.devservices.additional-env."additional-env"`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env[`quarkus.neo4j.devservices.additional-env."additional-env"`]##
 
 [.description]
 --
@@ -76,7 +75,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-bolt-port]] [.property-path]##`quarkus.neo4j.devservices.bolt-port`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-bolt-port]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-bolt-port[`quarkus.neo4j.devservices.bolt-port`]##
 
 [.description]
 --
@@ -93,7 +92,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-http-port]] [.property-path]##`quarkus.neo4j.devservices.http-port`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-http-port]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-http-port[`quarkus.neo4j.devservices.http-port`]##
 
 [.description]
 --
@@ -110,7 +109,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
-a| [[quarkus-neo4j_quarkus-neo4j-uri]] [.property-path]##`quarkus.neo4j.uri`##
+a| [[quarkus-neo4j_quarkus-neo4j-uri]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-uri[`quarkus.neo4j.uri`]##
 
 [.description]
 --
@@ -127,7 +126,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`bolt://localhost:7687`
 
-a| [[quarkus-neo4j_quarkus-neo4j-encrypted]] [.property-path]##`quarkus.neo4j.encrypted`##
+a| [[quarkus-neo4j_quarkus-neo4j-encrypted]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-encrypted[`quarkus.neo4j.encrypted`]##
 
 [.description]
 --
@@ -144,7 +143,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-max-transaction-retry-time]] [.property-path]##`quarkus.neo4j.max-transaction-retry-time`##
+a| [[quarkus-neo4j_quarkus-neo4j-max-transaction-retry-time]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-max-transaction-retry-time[`quarkus.neo4j.max-transaction-retry-time`]##
 
 [.description]
 --
@@ -158,14 +157,14 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_MAX_TRANSACTION_RETRY_TIME+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`30S`
 
-h|[[quarkus-neo4j_section_quarkus-neo4j-authentication]] [.section-name.section-level0]##the authentication##
+h|[[quarkus-neo4j_section_quarkus-neo4j-authentication]] [.section-name.section-level0]##link:#quarkus-neo4j_section_quarkus-neo4j-authentication[return the authentication++}++]##
 h|Type
 h|Default
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-username]] [.property-path]##`quarkus.neo4j.authentication.username`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-username]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-username[`quarkus.neo4j.authentication.username`]##
 
 [.description]
 --
@@ -182,7 +181,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`neo4j`
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-password]] [.property-path]##`quarkus.neo4j.authentication.password`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-password]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-password[`quarkus.neo4j.authentication.password`]##
 
 [.description]
 --
@@ -199,7 +198,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`neo4j`
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-disabled]] [.property-path]##`quarkus.neo4j.authentication.disabled`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-disabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-disabled[`quarkus.neo4j.authentication.disabled`]##
 
 [.description]
 --
@@ -216,7 +215,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-value]] [.property-path]##`quarkus.neo4j.authentication.value`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-value]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-value[`quarkus.neo4j.authentication.value`]##
 
 [.description]
 --
@@ -234,11 +233,11 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-h|[[quarkus-neo4j_section_quarkus-neo4j-trust-settings]] [.section-name.section-level0]##the trust settings for encrypted traffic##
+h|[[quarkus-neo4j_section_quarkus-neo4j-trust-settings]] [.section-name.section-level0]##link:#quarkus-neo4j_section_quarkus-neo4j-trust-settings[return the trust settings for encrypted traffic++}++]##
 h|Type
 h|Default
 
-a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-strategy]] [.property-path]##`quarkus.neo4j.trust-settings.strategy`##
+a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-strategy]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-trust-settings-strategy[`quarkus.neo4j.trust-settings.strategy`]##
 
 [.description]
 --
@@ -252,10 +251,10 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_TRUST_SETTINGS_STRATEGY+++`
 endif::add-copy-button-to-env-var[]
 --
-a|Strategy
+a|`trust-all-certificates`, `trust-custom-ca-signed-certificates`, `trust-system-ca-signed-certificates`
 |`trust-system-ca-signed-certificates`
 
-a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-cert-file]] [.property-path]##`quarkus.neo4j.trust-settings.cert-file`##
+a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-cert-file]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-trust-settings-cert-file[`quarkus.neo4j.trust-settings.cert-file`]##
 
 [.description]
 --
@@ -272,7 +271,7 @@ endif::add-copy-button-to-env-var[]
 |path
 |
 
-a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-hostname-verification-enabled]] [.property-path]##`quarkus.neo4j.trust-settings.hostname-verification-enabled`##
+a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-hostname-verification-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-trust-settings-hostname-verification-enabled[`quarkus.neo4j.trust-settings.hostname-verification-enabled`]##
 
 [.description]
 --
@@ -290,11 +289,11 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-h|[[quarkus-neo4j_section_quarkus-neo4j-pool]] [.section-name.section-level0]##the connection pool##
+h|[[quarkus-neo4j_section_quarkus-neo4j-pool]] [.section-name.section-level0]##link:#quarkus-neo4j_section_quarkus-neo4j-pool[return the connection pool++}++]##
 h|Type
 h|Default
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-metrics-enabled]] [.property-path]##`quarkus.neo4j.pool.metrics.enabled`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-metrics-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-metrics-enabled[`quarkus.neo4j.pool.metrics.enabled`]##
 
 [.description]
 --
@@ -311,7 +310,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-log-leaked-sessions]] [.property-path]##`quarkus.neo4j.pool.log-leaked-sessions`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-log-leaked-sessions]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-log-leaked-sessions[`quarkus.neo4j.pool.log-leaked-sessions`]##
 
 [.description]
 --
@@ -328,7 +327,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-pool-size]] [.property-path]##`quarkus.neo4j.pool.max-connection-pool-size`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-pool-size]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-max-connection-pool-size[`quarkus.neo4j.pool.max-connection-pool-size`]##
 
 [.description]
 --
@@ -345,7 +344,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`100`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-idle-time-before-connection-test]] [.property-path]##`quarkus.neo4j.pool.idle-time-before-connection-test`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-idle-time-before-connection-test]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-idle-time-before-connection-test[`quarkus.neo4j.pool.idle-time-before-connection-test`]##
 
 [.description]
 --
@@ -359,10 +358,10 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_POOL_IDLE_TIME_BEFORE_CONNECTION_TEST+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`-0.001S`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-lifetime]] [.property-path]##`quarkus.neo4j.pool.max-connection-lifetime`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-lifetime]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-max-connection-lifetime[`quarkus.neo4j.pool.max-connection-lifetime`]##
 
 [.description]
 --
@@ -376,10 +375,10 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_POOL_MAX_CONNECTION_LIFETIME+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`1H`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-connection-acquisition-timeout]] [.property-path]##`quarkus.neo4j.pool.connection-acquisition-timeout`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-connection-acquisition-timeout]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-connection-acquisition-timeout[`quarkus.neo4j.pool.connection-acquisition-timeout`]##
 
 [.description]
 --
@@ -393,7 +392,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_POOL_CONNECTION_ACQUISITION_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`1M`
 
 
@@ -418,5 +417,3 @@ In other cases, the simplified format is translated to the `java.time.Duration` 
 * If the value is a number followed by `d`, it is prefixed with `P`.
 ====
 endif::no-duration-note[]
-
-:!summaryTableId:

--- a/docs/modules/ROOT/pages/includes/quarkus-neo4j_quarkus.neo4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-neo4j_quarkus.neo4j.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-neo4j_quarkus-neo4j
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -8,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-health-enabled]] [.property-path]##`quarkus.neo4j.health.enabled`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-health-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-health-enabled[`quarkus.neo4j.health.enabled`]##
 
 [.description]
 --
@@ -25,7 +24,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-enabled]] [.property-path]##`quarkus.neo4j.devservices.enabled`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-enabled[`quarkus.neo4j.devservices.enabled`]##
 
 [.description]
 --
@@ -42,7 +41,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-image-name]] [.property-path]##`quarkus.neo4j.devservices.image-name`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-image-name]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-image-name[`quarkus.neo4j.devservices.image-name`]##
 
 [.description]
 --
@@ -59,7 +58,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`neo4j:5`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env]] [.property-path]##`quarkus.neo4j.devservices.additional-env."additional-env"`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-additional-env-additional-env[`quarkus.neo4j.devservices.additional-env."additional-env"`]##
 
 [.description]
 --
@@ -76,7 +75,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-bolt-port]] [.property-path]##`quarkus.neo4j.devservices.bolt-port`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-bolt-port]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-bolt-port[`quarkus.neo4j.devservices.bolt-port`]##
 
 [.description]
 --
@@ -93,7 +92,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-http-port]] [.property-path]##`quarkus.neo4j.devservices.http-port`##
+a|icon:lock[title=Fixed at build time] [[quarkus-neo4j_quarkus-neo4j-devservices-http-port]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-devservices-http-port[`quarkus.neo4j.devservices.http-port`]##
 
 [.description]
 --
@@ -110,7 +109,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
-a| [[quarkus-neo4j_quarkus-neo4j-uri]] [.property-path]##`quarkus.neo4j.uri`##
+a| [[quarkus-neo4j_quarkus-neo4j-uri]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-uri[`quarkus.neo4j.uri`]##
 
 [.description]
 --
@@ -127,7 +126,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`bolt://localhost:7687`
 
-a| [[quarkus-neo4j_quarkus-neo4j-encrypted]] [.property-path]##`quarkus.neo4j.encrypted`##
+a| [[quarkus-neo4j_quarkus-neo4j-encrypted]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-encrypted[`quarkus.neo4j.encrypted`]##
 
 [.description]
 --
@@ -144,7 +143,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-max-transaction-retry-time]] [.property-path]##`quarkus.neo4j.max-transaction-retry-time`##
+a| [[quarkus-neo4j_quarkus-neo4j-max-transaction-retry-time]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-max-transaction-retry-time[`quarkus.neo4j.max-transaction-retry-time`]##
 
 [.description]
 --
@@ -158,14 +157,14 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_MAX_TRANSACTION_RETRY_TIME+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`30S`
 
-h|[[quarkus-neo4j_section_quarkus-neo4j-authentication]] [.section-name.section-level0]##the authentication##
+h|[[quarkus-neo4j_section_quarkus-neo4j-authentication]] [.section-name.section-level0]##link:#quarkus-neo4j_section_quarkus-neo4j-authentication[return the authentication++}++]##
 h|Type
 h|Default
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-username]] [.property-path]##`quarkus.neo4j.authentication.username`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-username]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-username[`quarkus.neo4j.authentication.username`]##
 
 [.description]
 --
@@ -182,7 +181,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`neo4j`
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-password]] [.property-path]##`quarkus.neo4j.authentication.password`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-password]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-password[`quarkus.neo4j.authentication.password`]##
 
 [.description]
 --
@@ -199,7 +198,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`neo4j`
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-disabled]] [.property-path]##`quarkus.neo4j.authentication.disabled`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-disabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-disabled[`quarkus.neo4j.authentication.disabled`]##
 
 [.description]
 --
@@ -216,7 +215,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-authentication-value]] [.property-path]##`quarkus.neo4j.authentication.value`##
+a| [[quarkus-neo4j_quarkus-neo4j-authentication-value]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-authentication-value[`quarkus.neo4j.authentication.value`]##
 
 [.description]
 --
@@ -234,11 +233,11 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-h|[[quarkus-neo4j_section_quarkus-neo4j-trust-settings]] [.section-name.section-level0]##the trust settings for encrypted traffic##
+h|[[quarkus-neo4j_section_quarkus-neo4j-trust-settings]] [.section-name.section-level0]##link:#quarkus-neo4j_section_quarkus-neo4j-trust-settings[return the trust settings for encrypted traffic++}++]##
 h|Type
 h|Default
 
-a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-strategy]] [.property-path]##`quarkus.neo4j.trust-settings.strategy`##
+a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-strategy]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-trust-settings-strategy[`quarkus.neo4j.trust-settings.strategy`]##
 
 [.description]
 --
@@ -252,10 +251,10 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_TRUST_SETTINGS_STRATEGY+++`
 endif::add-copy-button-to-env-var[]
 --
-a|Strategy
+a|`trust-all-certificates`, `trust-custom-ca-signed-certificates`, `trust-system-ca-signed-certificates`
 |`trust-system-ca-signed-certificates`
 
-a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-cert-file]] [.property-path]##`quarkus.neo4j.trust-settings.cert-file`##
+a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-cert-file]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-trust-settings-cert-file[`quarkus.neo4j.trust-settings.cert-file`]##
 
 [.description]
 --
@@ -272,7 +271,7 @@ endif::add-copy-button-to-env-var[]
 |path
 |
 
-a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-hostname-verification-enabled]] [.property-path]##`quarkus.neo4j.trust-settings.hostname-verification-enabled`##
+a| [[quarkus-neo4j_quarkus-neo4j-trust-settings-hostname-verification-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-trust-settings-hostname-verification-enabled[`quarkus.neo4j.trust-settings.hostname-verification-enabled`]##
 
 [.description]
 --
@@ -290,11 +289,11 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-h|[[quarkus-neo4j_section_quarkus-neo4j-pool]] [.section-name.section-level0]##the connection pool##
+h|[[quarkus-neo4j_section_quarkus-neo4j-pool]] [.section-name.section-level0]##link:#quarkus-neo4j_section_quarkus-neo4j-pool[return the connection pool++}++]##
 h|Type
 h|Default
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-metrics-enabled]] [.property-path]##`quarkus.neo4j.pool.metrics.enabled`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-metrics-enabled]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-metrics-enabled[`quarkus.neo4j.pool.metrics.enabled`]##
 
 [.description]
 --
@@ -311,7 +310,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-log-leaked-sessions]] [.property-path]##`quarkus.neo4j.pool.log-leaked-sessions`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-log-leaked-sessions]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-log-leaked-sessions[`quarkus.neo4j.pool.log-leaked-sessions`]##
 
 [.description]
 --
@@ -328,7 +327,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-pool-size]] [.property-path]##`quarkus.neo4j.pool.max-connection-pool-size`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-pool-size]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-max-connection-pool-size[`quarkus.neo4j.pool.max-connection-pool-size`]##
 
 [.description]
 --
@@ -345,7 +344,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`100`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-idle-time-before-connection-test]] [.property-path]##`quarkus.neo4j.pool.idle-time-before-connection-test`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-idle-time-before-connection-test]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-idle-time-before-connection-test[`quarkus.neo4j.pool.idle-time-before-connection-test`]##
 
 [.description]
 --
@@ -359,10 +358,10 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_POOL_IDLE_TIME_BEFORE_CONNECTION_TEST+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`-0.001S`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-lifetime]] [.property-path]##`quarkus.neo4j.pool.max-connection-lifetime`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-max-connection-lifetime]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-max-connection-lifetime[`quarkus.neo4j.pool.max-connection-lifetime`]##
 
 [.description]
 --
@@ -376,10 +375,10 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_POOL_MAX_CONNECTION_LIFETIME+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`1H`
 
-a| [[quarkus-neo4j_quarkus-neo4j-pool-connection-acquisition-timeout]] [.property-path]##`quarkus.neo4j.pool.connection-acquisition-timeout`##
+a| [[quarkus-neo4j_quarkus-neo4j-pool-connection-acquisition-timeout]] [.property-path]##link:#quarkus-neo4j_quarkus-neo4j-pool-connection-acquisition-timeout[`quarkus.neo4j.pool.connection-acquisition-timeout`]##
 
 [.description]
 --
@@ -393,7 +392,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NEO4J_POOL_CONNECTION_ACQUISITION_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --
-|link:https://docs.oracle.com/en/java/javase/17/docs/api/java/time/Duration.html[Duration] link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-neo4j_quarkus-neo4j[icon:question-circle[title=More information about the Duration format]]
 |`1M`
 
 
@@ -418,5 +417,3 @@ In other cases, the simplified format is translated to the `java.time.Duration` 
 * If the value is a number followed by `d`, it is prefixed with `P`.
 ====
 endif::no-duration-note[]
-
-:!summaryTableId:

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.neo4j</groupId>
         <artifactId>quarkus-neo4j-parent</artifactId>
-        <version>4.4.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.neo4j</groupId>
         <artifactId>quarkus-neo4j-parent</artifactId>
-        <version>4.4.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-neo4j-integration-tests</artifactId>
     <name>Quarkus - Neo4j - Integration Tests</name>
@@ -13,7 +13,7 @@
     <properties>
         <neo4j.uri>bolt://localhost:60513</neo4j.uri>
         <neo4j.username>neo4j</neo4j.username>
-        <neo4j.password>secret</neo4j.password>
+        <neo4j.password>verysecret</neo4j.password>
     </properties>
 
     <dependencies>
@@ -85,7 +85,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>neo4j:4.4</name>
+                            <name>neo4j:5</name>
                             <run>
                                 <ports>
                                     <port>60513:7687</port>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>io.quarkiverse.neo4j</groupId>
   <artifactId>quarkus-neo4j-parent</artifactId>
-  <version>4.4.1-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Quarkus - Neo4j - Parent</name>
   <modules>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.neo4j</groupId>
         <artifactId>quarkus-neo4j-parent</artifactId>
-        <version>4.4.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-neo4j</artifactId>
     <name>Quarkus - Neo4j - Runtime</name>


### PR DESCRIPTION
This closes #299 and I think in the long run, developer experience will be better.
Until this change we used any locally running Neo4j instance reachable on 7687.
While this is helpful when working on it from other programs, it might not be so helpful in terms of

* the general dev experience ("Why doesn't it bring something up, I did not configure it elsewise?")
* one doesn't notice it didn't startup anything separate and an integration tests nukes some production data on 7687

The old behaviour can easily be recreated by either specifiying the localhost:7687 Neo4j uri via `quarkus.neo4j.uri` or
if this doesn't work for reasons, point the fixed bolt port in devservices to the locally running instance like this
`quarkus.neo4j.devservices.bolt-port=7687`.

We do consider this a breaking change and will bump the version of Quarkus Neo4j from 4.4 to 5.0, which will be inline with further planned features.
