### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
@@ -28,7 +28,7 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServiceDescriptionBuildItem;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
@@ -60,14 +60,14 @@ class Neo4jDevServicesProcessor {
 
     private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     public DevServicesResultBuildItem startNeo4jDevService(
             LaunchModeBuildItem launchMode,
             Neo4jBuildTimeConfig neo4jBuildTimeConfig,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
-            GlobalDevServicesConfig globalDevServicesConfig,
+            DevServicesConfig devServicesConfig,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
 
         var configuration = new Neo4jDevServiceConfig(neo4jBuildTimeConfig.devservices());
@@ -85,10 +85,10 @@ class Neo4jDevServicesProcessor {
                 loggingSetupBuildItem);
 
         try {
-            boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(globalDevServicesConfig,
+            boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                     devServicesSharedNetworkBuildItem);
             devService = startNeo4j(configuration, launchMode.getLaunchMode(), useSharedNetwork,
-                    globalDevServicesConfig.timeout);
+                    devServicesConfig.timeout());
         } catch (Throwable t) {
             compressor.closeAndDumpCaptured();
             throw new RuntimeException(t);
@@ -112,7 +112,7 @@ class Neo4jDevServicesProcessor {
         return devService == null ? null : devService.toBuildItem();
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     @Consume(DevServicesResultBuildItem.class)
     DevServiceDescriptionBuildItem renderDevServiceDevUICard() {
         return devService == null ? null


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in Quarkus 3.26 (we deprecated it in Quarkus 3.19).